### PR TITLE
installation support custom release name

### DIFF
--- a/cmd/groundcover/deploy.go
+++ b/cmd/groundcover/deploy.go
@@ -27,6 +27,8 @@ const (
 	AUTO_DEPLOYMENT_TAG           = "auto"
 	GROUNDCOVER_NAMESPACE_FLAG    = "groundcover-namespace"
 	DEFAULT_GROUNDCOVER_NAMESPACE = "groundcover"
+	GROUNDCOVER_HELM_RELEASE_FLAG = "groundcover-release"
+	DEFAULT_GROUNDCOVER_RELEASE   = "groundcover"
 )
 
 var (
@@ -90,14 +92,15 @@ var DeployCmd = &cobra.Command{
 		fmt.Printf("Installing groundcover version: %s\n", version)
 
 		groundcoverNamespace := viper.GetString(GROUNDCOVER_NAMESPACE_FLAG)
+		groundcoverReleaseName := viper.GetString(GROUNDCOVER_HELM_RELEASE_FLAG)
 		automatedInstallation := utils.YesNoPrompt("Do you want to run automated installation", true)
 		if !automatedInstallation {
 			cs.CaptureDeploymentEvent(customClaims, MANUAL_DEPLOYMENT_TAG, version, numberOfNodes)
-			return manualInstallation(helmCmd, apiKey.ApiKey, formattedClusterName, groundcoverNamespace)
+			return manualInstallation(helmCmd, apiKey.ApiKey, formattedClusterName, groundcoverNamespace, groundcoverReleaseName)
 		}
 
 		cs.CaptureDeploymentEvent(customClaims, AUTO_DEPLOYMENT_TAG, version, numberOfNodes)
-		return autoInstallation(cmd.Context(), helmCmd, metadataFetcher, apiKey.ApiKey, formattedClusterName, groundcoverNamespace)
+		return autoInstallation(cmd.Context(), helmCmd, metadataFetcher, apiKey.ApiKey, formattedClusterName, groundcoverNamespace, groundcoverReleaseName)
 	},
 }
 
@@ -114,7 +117,7 @@ func getClusterName(cmd *cobra.Command) (string, error) {
 	return clusterName, nil
 }
 
-func autoInstallation(ctx context.Context, helmCmd *helm.HelmCmd, metadataFetcher *k8s.MetadataFetcher, apiKey, clusterName, groundcoverNamespace string) error {
+func autoInstallation(ctx context.Context, helmCmd *helm.HelmCmd, metadataFetcher *k8s.MetadataFetcher, apiKey, clusterName, groundcoverNamespace, groundcoverReleaseName string) error {
 	fmt.Println("Installing groundcover...")
 
 	err := helmCmd.RepoAdd(ctx)
@@ -127,7 +130,7 @@ func autoInstallation(ctx context.Context, helmCmd *helm.HelmCmd, metadataFetche
 		return err
 	}
 
-	err = helmCmd.Upgrade(ctx, apiKey, clusterName, groundcoverNamespace)
+	err = helmCmd.Upgrade(ctx, apiKey, clusterName, groundcoverNamespace, groundcoverReleaseName)
 	if err != nil {
 		return err
 	}
@@ -153,9 +156,9 @@ func autoInstallation(ctx context.Context, helmCmd *helm.HelmCmd, metadataFetche
 	return nil
 }
 
-func manualInstallation(helmCmd *helm.HelmCmd, apiKey, clusterName, groundcoverNamespace string) error {
+func manualInstallation(helmCmd *helm.HelmCmd, apiKey, clusterName, groundcoverNamespace, groundcoverReleaseName string) error {
 	fmt.Print("To deploy groundcover please run the following command:\n")
 	fmt.Print("\n\n")
-	fmt.Printf(helmCmd.BuildInstallCommand(apiKey, clusterName, groundcoverNamespace))
+	fmt.Print(helmCmd.BuildInstallCommand(apiKey, clusterName, groundcoverNamespace, groundcoverReleaseName))
 	return nil
 }

--- a/cmd/groundcover/deploy.go
+++ b/cmd/groundcover/deploy.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -31,15 +30,8 @@ const (
 	DEFAULT_GROUNDCOVER_RELEASE   = "groundcover"
 )
 
-var (
-	waitForClusterConnectedToSaasTimeout = time.Minute * 5
-)
-
 func init() {
 	RootCmd.AddCommand(DeployCmd)
-
-	DeployCmd.PersistentFlags().Bool(MANUAL_FLAG, true, "install groundcover helm chart manually")
-	viper.BindPFlag(MANUAL_FLAG, DeployCmd.PersistentFlags().Lookup(MANUAL_FLAG))
 
 	DeployCmd.PersistentFlags().String(CLUSTER_NAME_FLAG, "", "cluster name")
 	viper.BindPFlag(CLUSTER_NAME_FLAG, DeployCmd.PersistentFlags().Lookup(CLUSTER_NAME_FLAG))

--- a/cmd/groundcover/root.go
+++ b/cmd/groundcover/root.go
@@ -30,6 +30,9 @@ func init() {
 
 	RootCmd.PersistentFlags().String(GROUNDCOVER_NAMESPACE_FLAG, DEFAULT_GROUNDCOVER_NAMESPACE, "groundcover deployment namespace")
 	viper.BindPFlag(GROUNDCOVER_NAMESPACE_FLAG, RootCmd.PersistentFlags().Lookup(GROUNDCOVER_NAMESPACE_FLAG))
+
+	RootCmd.PersistentFlags().String(GROUNDCOVER_HELM_RELEASE_FLAG, DEFAULT_GROUNDCOVER_RELEASE, "groundcover chart release name")
+	viper.BindPFlag(GROUNDCOVER_HELM_RELEASE_FLAG, RootCmd.PersistentFlags().Lookup(GROUNDCOVER_HELM_RELEASE_FLAG))
 }
 
 var RootCmd = &cobra.Command{

--- a/cmd/groundcover/uninstall.go
+++ b/cmd/groundcover/uninstall.go
@@ -11,9 +11,7 @@ import (
 )
 
 const (
-	GROUNDCOVER_HELM_RELEASE_FLAG = "groundcover-release"
-	GROUNDCOVER_HELM_RELEASE_NAME = "groundcover"
-	TSDB_SERVICE_CONFIG_NAME      = "service/groundcover-tsdb-config"
+	TSDB_SERVICE_CONFIG_NAME = "service/groundcover-tsdb-config"
 )
 
 var (
@@ -22,9 +20,6 @@ var (
 
 func init() {
 	RootCmd.AddCommand(UninstallCmd)
-
-	UninstallCmd.PersistentFlags().String(GROUNDCOVER_HELM_RELEASE_FLAG, GROUNDCOVER_HELM_RELEASE_NAME, "groundcover release name")
-	viper.BindPFlag(GROUNDCOVER_HELM_RELEASE_FLAG, UninstallCmd.PersistentFlags().Lookup(GROUNDCOVER_HELM_RELEASE_FLAG))
 }
 
 var UninstallCmd = &cobra.Command{

--- a/cmd/groundcover/uninstall.go
+++ b/cmd/groundcover/uninstall.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	TSDB_SERVICE_CONFIG_NAME = "service/groundcover-tsdb-config"
-	RELEASE_LABEL_KEY        = "release"
-	APP_K8S_IO_LABEL_KEY     = "app.kubernetes.io/instance"
+	TSDB_SERVICE_CONFIG_NAME  = "service/groundcover-tsdb-config"
+	TSDB_ENDPOINT_CONFIG_NAME = "endpoints/groundcover-tsdb"
+	RELEASE_LABEL_KEY         = "release"
+	APP_K8S_IO_LABEL_KEY      = "app.kubernetes.io/instance"
 )
 
 func buildPVCLabels(releaseName string) []string {
@@ -47,6 +48,11 @@ var UninstallCmd = &cobra.Command{
 		}
 
 		err = helmCmd.Uninstall(cmd.Context(), groundcoverNamespace, viper.GetString(GROUNDCOVER_HELM_RELEASE_FLAG))
+		if err != nil {
+			return err
+		}
+
+		err = kubectl.Delete(cmd.Context(), groundcoverNamespace, TSDB_ENDPOINT_CONFIG_NAME)
 		if err != nil {
 			return err
 		}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -53,8 +53,8 @@ func getHelmExecutablePath() (string, error) {
 	return helmPath, nil
 }
 
-func (h *HelmCmd) Upgrade(ctx context.Context, apiKey string, clusterName string, namespace string) error {
-	_, err := utils.ExecuteCommand(h.helmPath, "upgrade", "--install", h.repoName, h.chartName,
+func (h *HelmCmd) Upgrade(ctx context.Context, apiKey, clusterName, namespace, releaseName string) error {
+	_, err := utils.ExecuteCommand(h.helmPath, "upgrade", "--install", releaseName, h.chartName,
 		"--set", fmt.Sprintf("global.groundcover_token=%s", apiKey),
 		"--set", fmt.Sprintf("clusterId=%s", clusterName),
 		"--create-namespace", "-n", namespace,
@@ -128,12 +128,12 @@ func (h *HelmCmd) ShowChartCommand(ctx context.Context) (string, error) {
 	return output, nil
 }
 
-func (h *HelmCmd) BuildInstallCommand(apiKey, clusterName, namespace string) string {
+func (h *HelmCmd) BuildInstallCommand(apiKey, clusterName, namespace, releaseName string) string {
 	return fmt.Sprintf("helm repo add %s %s && helm repo update %s && helm upgrade --install %s %s --set global.groundcover_token=%s,clusterId=%s --create-namespace -n %s\n",
 		h.repoName,
 		h.repoAddr,
 		h.repoName,
-		h.repoName,
+		releaseName,
 		h.chartName,
 		apiKey,
 		clusterName,


### PR DESCRIPTION
also removed uninstall redundant consts

fixed another bug discovered during this pr - the uninstallation assumed the release name is groundcover even though it was customizable 