### PR TITLE
[sc-12837] install flow should wait for static amount of pvcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use the following categories for changes:
 ### Changed
 
 ### Fixed
+- CLI should expect a static amount of PVCs [#sc-12837]
 
 ### Removed
 


### PR DESCRIPTION
In some cases installing the helm chart does not result in PVCs getting created. Currently this results in a clean return with nil error, which then leads to faulty installations.

This PR changes the way the CLI gets the expected number of PVCs to wait for in the waitForPVCs function - to a static amount and not dynamic according to kubectl result.