### PR TITLE
[sc-15043] groundcover 1.7.35 - postgresql resource presets

### DIFF
--- a/pkg/helm/presets/backend/high-resources.yaml
+++ b/pkg/helm/presets/backend/high-resources.yaml
@@ -74,3 +74,17 @@ victoria-metrics-single:
       limits:
         cpu: 1000m
         memory: 5000Mi
+
+backend:
+  postgresql:
+    primary:
+      # based on https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15 - "large"
+      resources:
+        requests:
+          cpu: 1
+          memory: 2048Mi
+          ephemeral-storage: 50Mi
+        limits:
+          cpu: 1.5
+          memory: 3072Mi
+          ephemeral-storage: 1024Mi

--- a/pkg/helm/presets/backend/huge-resources.yaml
+++ b/pkg/helm/presets/backend/huge-resources.yaml
@@ -73,3 +73,17 @@ victoria-metrics-single:
         memory: 5000Mi
       limits:
         memory: 6Gi
+
+backend:
+  postgresql:
+    primary:
+      # based on https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15 - "xlarge"
+      resources:
+        requests:
+          cpu: 1.5
+          memory: 4096Mi
+          ephemeral-storage: 50Mi
+        limits:
+          cpu: 3.0
+          memory: 6144Mi
+          ephemeral-storage: 1024Mi

--- a/pkg/helm/presets/backend/low-resources.yaml
+++ b/pkg/helm/presets/backend/low-resources.yaml
@@ -70,3 +70,17 @@ victoria-metrics-single:
       limits:
         cpu: 100m
         memory: 1024Mi
+
+backend:
+  postgresql:
+    primary:
+      # based on https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15 - "small"
+      resources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
+          ephemeral-storage: 50Mi
+        limits:
+          cpu: 750m
+          memory: 768Mi
+          ephemeral-storage: 1024Mi


### PR DESCRIPTION
Define resource presets for postgresql introduced as part of groundcover helm chart 1.7.35 version.

Using common preset based on https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15 we the mapping is defined as:

|         | groundcover CLI | bitnami common | 
|---------|-----------------|-----------------|
| **preset**  | low             | small           |
| **preset**  | high            | large           |
| **preset**  | huge            | xlarge          |