### PR TITLE
[sc-16445] override slice values on redeploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ We use the following categories for changes:
 
 ### Changed
 
+- Override slice values on redeploy [#sc-16445]
+
 ### Fixed
 
 ### Removed

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -668,7 +668,7 @@ func generateChartValues(chartValues map[string]interface{}, apiKey, installatio
 		chartValues["agent"] = map[string]interface{}{"tolerations": tolerations}
 	}
 
-	if err = mergo.Merge(&chartValues, valuesOverride, mergo.WithSliceDeepCopy); err != nil {
+	if err = mergo.Merge(&chartValues, valuesOverride, mergo.WithOverride); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This changes the way the CLI merges value overrides with existing values already deployed in the chart. Previously slices were merged with deep copy; this caused issues when changing configurations like extraScrapeJobs or logsDropFilters, creating inconsistent behaviors.

After this change, the value will always be fully overwritten by the provided overrides - assuming one was given. 