### PR TITLE
fix: typo presistent->persistent

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -320,7 +320,7 @@ func waitForPvcs(ctx context.Context, kubeClient *k8s.Client, releaseName, names
 	}
 
 	if expectedBoundPvcsCount == 0 {
-		ui.GlobalWriter.PrintWarningMessageln("No Presistent volumes")
+		ui.GlobalWriter.PrintWarningMessageln("No Persistent volumes")
 		return nil
 	}
 

--- a/pkg/auth/auth0.go
+++ b/pkg/auth/auth0.go
@@ -40,7 +40,7 @@ func LoadAuth0Token() (*Auth0Token, error) {
 	var err error
 
 	var data []byte
-	if data, err = utils.PresistentStorage.Read(TOKEN_STORAGE_KEY); err != nil {
+	if data, err = utils.PersistentStorage.Read(TOKEN_STORAGE_KEY); err != nil {
 		return nil, err
 	}
 
@@ -66,7 +66,7 @@ func (auth0Token *Auth0Token) Save() error {
 		return err
 	}
 
-	return utils.PresistentStorage.Write(TOKEN_STORAGE_KEY, data)
+	return utils.PersistentStorage.Write(TOKEN_STORAGE_KEY, data)
 }
 
 func (auth0Token *Auth0Token) BearerToken() (string, error) {

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -22,7 +22,7 @@ type Client struct {
 func NewHelmClient(namespace, kubecontext string) (*Client, error) {
 	var err error
 
-	helmPath := filepath.Join(utils.PresistentStorage.BasePath, "helm")
+	helmPath := filepath.Join(utils.PersistentStorage.BasePath, "helm")
 
 	os.Setenv("HELM_DATA_HOME", helmPath)
 	os.Setenv("HELM_CACHE_HOME", helmPath)

--- a/pkg/utils/diskv.go
+++ b/pkg/utils/diskv.go
@@ -11,7 +11,7 @@ const (
 	STROAGE_PREFIX = ".groundcover"
 )
 
-var PresistentStorage *diskv.Diskv = NewStorage()
+var PersistentStorage *diskv.Diskv = NewStorage()
 
 func NewStorage() *diskv.Diskv {
 	var err error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected multiple typos in user-facing messages and internal references, ensuring proper spelling of "Persistent" in warning messages and storage-related functionality. 

- **Chores**
  - Standardized variable and identifier names for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->