### PR TITLE
fix: respect --tenant-uuid flag

### DIFF
--- a/cmd/api_key.go
+++ b/cmd/api_key.go
@@ -13,7 +13,7 @@ var apiKeyCmd = &cobra.Command{
 		var err error
 
 		var tenantUUID string
-		if tenantUUID, _, err = fetchTenantOrUseFlag(); err != nil {
+		if tenantUUID, err = getTenantUUID(); err != nil {
 			return err
 		}
 

--- a/cmd/api_key.go
+++ b/cmd/api_key.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
 	"groundcover.com/pkg/ui"
 )
@@ -15,12 +13,8 @@ var apiKeyCmd = &cobra.Command{
 		var err error
 
 		var tenantUUID string
-		var tenant *api.TenantInfo
-		if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
-			if tenant, err = fetchTenant(); err != nil {
-				return err
-			}
-			tenantUUID = tenant.UUID
+		if tenantUUID, _, err = fetchTenantOrUseFlag(); err != nil {
+			return err
 		}
 
 		var apiKey *auth.ApiKey

--- a/cmd/api_key.go
+++ b/cmd/api_key.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
 	"groundcover.com/pkg/ui"
@@ -13,13 +14,17 @@ var apiKeyCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 
+		var tenantUUID string
 		var tenant *api.TenantInfo
-		if tenant, err = fetchTenant(); err != nil {
-			return err
+		if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
+			if tenant, err = fetchTenant(); err != nil {
+				return err
+			}
+			tenantUUID = tenant.UUID
 		}
 
 		var apiKey *auth.ApiKey
-		if apiKey, err = fetchApiKey(tenant.UUID); err != nil {
+		if apiKey, err = fetchApiKey(tenantUUID); err != nil {
 			return err
 		}
 

--- a/cmd/generate_client_token.go
+++ b/cmd/generate_client_token.go
@@ -13,13 +13,13 @@ var generateClientTokenCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 
-		var tenant *api.TenantInfo
-		if _, tenant, err = fetchTenantOrUseFlag(); err != nil {
+		var tenantUUID string
+		if tenantUUID, err = getTenantUUID(); err != nil {
 			return err
 		}
 
 		var apiToken *auth.ApiKey
-		if apiToken, err = fetchClientToken(tenant); err != nil {
+		if apiToken, err = fetchClientToken(tenantUUID); err != nil {
 			return err
 		}
 
@@ -29,7 +29,7 @@ var generateClientTokenCmd = &cobra.Command{
 	},
 }
 
-func fetchClientToken(tenant *api.TenantInfo) (*auth.ApiKey, error) {
+func fetchClientToken(tenantUUID string) (*auth.ApiKey, error) {
 	var err error
 
 	var auth0Token *auth.Auth0Token
@@ -40,7 +40,7 @@ func fetchClientToken(tenant *api.TenantInfo) (*auth.ApiKey, error) {
 	apiClient := api.NewClient(auth0Token)
 
 	var clientToken *auth.ApiKey
-	if clientToken, err = apiClient.GetOrCreateClientToken(tenant); err != nil {
+	if clientToken, err = apiClient.GetOrCreateClientToken(tenantUUID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/generate_client_token.go
+++ b/cmd/generate_client_token.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
 	"groundcover.com/pkg/ui"
@@ -14,15 +13,9 @@ var generateClientTokenCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 
-		var tenantUUID string
 		var tenant *api.TenantInfo
-		if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
-			if tenant, err = fetchTenant(); err != nil {
-				return err
-			}
-			tenantUUID = tenant.UUID
-		} else {
-			tenant = &api.TenantInfo{UUID: tenantUUID}
+		if _, tenant, err = fetchTenantOrUseFlag(); err != nil {
+			return err
 		}
 
 		var apiToken *auth.ApiKey

--- a/cmd/generate_client_token.go
+++ b/cmd/generate_client_token.go
@@ -20,6 +20,7 @@ var generateClientTokenCmd = &cobra.Command{
 			if tenant, err = fetchTenant(); err != nil {
 				return err
 			}
+			tenantUUID = tenant.UUID
 		} else {
 			tenant = &api.TenantInfo{UUID: tenantUUID}
 		}

--- a/cmd/generate_client_token.go
+++ b/cmd/generate_client_token.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
 	"groundcover.com/pkg/ui"
@@ -13,9 +14,14 @@ var generateClientTokenCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 
+		var tenantUUID string
 		var tenant *api.TenantInfo
-		if tenant, err = fetchTenant(); err != nil {
-			return err
+		if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
+			if tenant, err = fetchTenant(); err != nil {
+				return err
+			}
+		} else {
+			tenant = &api.TenantInfo{UUID: tenantUUID}
 		}
 
 		var apiToken *auth.ApiKey

--- a/cmd/get_datasources_api_key.go
+++ b/cmd/get_datasources_api_key.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
 	"groundcover.com/pkg/ui"
@@ -13,13 +14,19 @@ var getDatasourcesAPIKeyCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 
+		var tenantUUID string
 		var tenant *api.TenantInfo
-		if tenant, err = fetchTenant(); err != nil {
-			return err
+		if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
+			if tenant, err = fetchTenant(); err != nil {
+				return err
+			}
+			tenantUUID = tenant.UUID
+		} else {
+			tenant = &api.TenantInfo{UUID: tenantUUID}
 		}
 
 		var backendName string
-		if backendName, _, err = selectBackendName(tenant.UUID, false); err != nil {
+		if backendName, _, err = selectBackendName(tenantUUID, false); err != nil {
 			return err
 		}
 

--- a/cmd/get_datasources_api_key.go
+++ b/cmd/get_datasources_api_key.go
@@ -14,8 +14,7 @@ var getDatasourcesAPIKeyCmd = &cobra.Command{
 		var err error
 
 		var tenantUUID string
-		var tenant *api.TenantInfo
-		if tenantUUID, tenant, err = fetchTenantOrUseFlag(); err != nil {
+		if tenantUUID, err = getTenantUUID(); err != nil {
 			return err
 		}
 
@@ -25,7 +24,7 @@ var getDatasourcesAPIKeyCmd = &cobra.Command{
 		}
 
 		var apiToken *auth.ApiKey
-		if apiToken, err = fetchDatasourcesAPIKey(tenant, backendName); err != nil {
+		if apiToken, err = fetchDatasourcesAPIKey(tenantUUID, backendName); err != nil {
 			return err
 		}
 
@@ -34,7 +33,7 @@ var getDatasourcesAPIKeyCmd = &cobra.Command{
 	},
 }
 
-func fetchDatasourcesAPIKey(tenant *api.TenantInfo, backendName string) (*auth.ApiKey, error) {
+func fetchDatasourcesAPIKey(tenantUUID string, backendName string) (*auth.ApiKey, error) {
 	var err error
 
 	var auth0Token *auth.Auth0Token
@@ -45,7 +44,7 @@ func fetchDatasourcesAPIKey(tenant *api.TenantInfo, backendName string) (*auth.A
 	apiClient := api.NewClient(auth0Token)
 
 	var apiToken *auth.ApiKey
-	if apiToken, err = apiClient.GetDatasourcesAPIKey(tenant, backendName); err != nil {
+	if apiToken, err = apiClient.GetDatasourcesAPIKey(tenantUUID, backendName); err != nil {
 		return nil, err
 	}
 

--- a/cmd/get_datasources_api_key.go
+++ b/cmd/get_datasources_api_key.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
 	"groundcover.com/pkg/ui"
@@ -16,13 +15,8 @@ var getDatasourcesAPIKeyCmd = &cobra.Command{
 
 		var tenantUUID string
 		var tenant *api.TenantInfo
-		if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
-			if tenant, err = fetchTenant(); err != nil {
-				return err
-			}
-			tenantUUID = tenant.UUID
-		} else {
-			tenant = &api.TenantInfo{UUID: tenantUUID}
+		if tenantUUID, tenant, err = fetchTenantOrUseFlag(); err != nil {
+			return err
 		}
 
 		var backendName string

--- a/cmd/ingestion_key.go
+++ b/cmd/ingestion_key.go
@@ -20,7 +20,7 @@ var IngestionKeyCmd = &cobra.Command{
 		var err error
 
 		var tenantUUID string
-		if tenantUUID, _, err = fetchTenantOrUseFlag(); err != nil {
+		if tenantUUID, err = getTenantUUID(); err != nil {
 			return err
 		}
 

--- a/cmd/ingestion_key.go
+++ b/cmd/ingestion_key.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
 	"groundcover.com/pkg/ui"
@@ -20,18 +19,14 @@ var IngestionKeyCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 
-		var auth0Token *auth.Auth0Token
-		if auth0Token, err = auth.LoadAuth0Token(); err != nil {
+		var tenantUUID string
+		if tenantUUID, _, err = fetchTenantOrUseFlag(); err != nil {
 			return err
 		}
 
-		var tenantUUID string
-		var tenant *api.TenantInfo
-		if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
-			if tenant, err = fetchTenant(); err != nil {
-				return err
-			}
-			tenantUUID = tenant.UUID
+		var auth0Token *auth.Auth0Token
+		if auth0Token, err = auth.LoadAuth0Token(); err != nil {
+			return err
 		}
 
 		var backendName string

--- a/cmd/ingestion_key_test.go
+++ b/cmd/ingestion_key_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIngestionKeyCmd_TenantUUIDFlag(t *testing.T) {
+	// Save original viper state
+	originalTenantUUID := viper.GetString(TENANT_UUID_FLAG)
+	defer viper.Set(TENANT_UUID_FLAG, originalTenantUUID)
+
+	tests := []struct {
+		name              string
+		tenantUUIDFlag    string
+		expectedBehavior  string
+	}{
+		{
+			name:             "tenant-uuid flag provided",
+			tenantUUIDFlag:   "test-tenant-uuid-123",
+			expectedBehavior: "should use provided tenant UUID",
+		},
+		{
+			name:             "tenant-uuid flag empty",
+			tenantUUIDFlag:   "",
+			expectedBehavior: "should call fetchTenant",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the flag value
+			viper.Set(TENANT_UUID_FLAG, tt.tenantUUIDFlag)
+
+			// Get the value back
+			result := viper.GetString(TENANT_UUID_FLAG)
+
+			// Assert
+			assert.Equal(t, tt.tenantUUIDFlag, result)
+		})
+	}
+}
+
+func TestTenantUUIDFlagBinding(t *testing.T) {
+	// Verify that TENANT_UUID_FLAG constant is correct
+	assert.Equal(t, "tenant-uuid", TENANT_UUID_FLAG)
+
+	// Verify the flag exists in RootCmd
+	flag := RootCmd.PersistentFlags().Lookup(TENANT_UUID_FLAG)
+	assert.NotNil(t, flag, "tenant-uuid flag should be registered")
+	assert.Equal(t, "", flag.DefValue, "tenant-uuid flag should have empty default value")
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -6,6 +6,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"golang.org/x/exp/maps"
 	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
@@ -116,6 +117,20 @@ func fetchTenant() (*api.TenantInfo, error) {
 		tenantName := ui.GlobalWriter.SelectPrompt("Select tenant:", maps.Keys(tenantsByName))
 		return tenantsByName[tenantName], nil
 	}
+}
+
+// fetchTenantOrUseFlag retrieves tenant information from the --tenant-uuid flag if provided,
+// otherwise fetches it from the API. Returns both the tenant UUID string and TenantInfo object.
+func fetchTenantOrUseFlag() (tenantUUID string, tenant *api.TenantInfo, err error) {
+	if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
+		if tenant, err = fetchTenant(); err != nil {
+			return "", nil, err
+		}
+		tenantUUID = tenant.UUID
+	} else {
+		tenant = &api.TenantInfo{UUID: tenantUUID}
+	}
+	return tenantUUID, tenant, nil
 }
 
 func fetchApiKey(tenantUUID string) (*auth.ApiKey, error) {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -119,18 +119,17 @@ func fetchTenant() (*api.TenantInfo, error) {
 	}
 }
 
-// fetchTenantOrUseFlag retrieves tenant information from the --tenant-uuid flag if provided,
-// otherwise fetches it from the API. Returns both the tenant UUID string and TenantInfo object.
-func fetchTenantOrUseFlag() (tenantUUID string, tenant *api.TenantInfo, err error) {
-	if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
-		if tenant, err = fetchTenant(); err != nil {
-			return "", nil, err
-		}
-		tenantUUID = tenant.UUID
-	} else {
-		tenant = &api.TenantInfo{UUID: tenantUUID}
+func getTenantUUID() (string, error) {
+	if tenantUUID := viper.GetString(TENANT_UUID_FLAG); tenantUUID != "" {
+		return tenantUUID, nil
 	}
-	return tenantUUID, tenant, nil
+
+	tenant, err := fetchTenant()
+	if err != nil {
+		return "", err
+	}
+
+	return tenant.UUID, nil
 }
 
 func fetchApiKey(tenantUUID string) (*auth.ApiKey, error) {

--- a/cmd/service_account.go
+++ b/cmd/service_account.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
 	"groundcover.com/pkg/ui"
@@ -15,12 +14,8 @@ var serviceAccountTokenCmd = &cobra.Command{
 		var err error
 
 		var tenantUUID string
-		var tenant *api.TenantInfo
-		if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
-			if tenant, err = fetchTenant(); err != nil {
-				return err
-			}
-			tenantUUID = tenant.UUID
+		if tenantUUID, _, err = fetchTenantOrUseFlag(); err != nil {
+			return err
 		}
 
 		var saToken *auth.SAToken

--- a/cmd/service_account.go
+++ b/cmd/service_account.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"groundcover.com/pkg/api"
 	"groundcover.com/pkg/auth"
 	"groundcover.com/pkg/ui"
@@ -13,13 +14,17 @@ var serviceAccountTokenCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 
+		var tenantUUID string
 		var tenant *api.TenantInfo
-		if tenant, err = fetchTenant(); err != nil {
-			return err
+		if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == "" {
+			if tenant, err = fetchTenant(); err != nil {
+				return err
+			}
+			tenantUUID = tenant.UUID
 		}
 
 		var saToken *auth.SAToken
-		if saToken, err = fetchServiceAccountToken(tenant.UUID); err != nil {
+		if saToken, err = fetchServiceAccountToken(tenantUUID); err != nil {
 			return err
 		}
 

--- a/cmd/service_account.go
+++ b/cmd/service_account.go
@@ -14,7 +14,7 @@ var serviceAccountTokenCmd = &cobra.Command{
 		var err error
 
 		var tenantUUID string
-		if tenantUUID, _, err = fetchTenantOrUseFlag(); err != nil {
+		if tenantUUID, err = getTenantUUID(); err != nil {
 			return err
 		}
 

--- a/cmd/tenant_uuid_flag_test.go
+++ b/cmd/tenant_uuid_flag_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
-	"groundcover.com/pkg/api"
 )
 
 type TenantUUIDFlagTestSuite struct {
@@ -119,44 +118,28 @@ func (suite *TenantUUIDFlagTestSuite) TestTenantUUIDFlagPattern() {
 	})
 }
 
-func (suite *TenantUUIDFlagTestSuite) TestFetchTenantOrUseFlag() {
+func (suite *TenantUUIDFlagTestSuite) TestGetTenantUUID() {
 	suite.Run("with tenant-uuid flag set", func() {
 		expectedUUID := "test-uuid-12345"
 		viper.Set(TENANT_UUID_FLAG, expectedUUID)
 
-		tenantUUID, tenant, err := fetchTenantOrUseFlag()
+		tenantUUID, err := getTenantUUID()
 
 		// Should not error
 		suite.NoError(err)
 
 		// Should return the UUID from flag
 		suite.Equal(expectedUUID, tenantUUID)
-
-		// Should create a TenantInfo with the UUID
-		suite.NotNil(tenant)
-		suite.Equal(expectedUUID, tenant.UUID)
 	})
 
-	suite.Run("return values structure", func() {
+	suite.Run("returns tenant UUID string", func() {
 		testUUID := "structure-test-uuid"
 		viper.Set(TENANT_UUID_FLAG, testUUID)
 
-		tenantUUID, tenant, err := fetchTenantOrUseFlag()
+		tenantUUID, err := getTenantUUID()
 
 		suite.NoError(err)
 		suite.NotEmpty(tenantUUID, "tenantUUID should be populated")
-		suite.NotNil(tenant, "tenant should be populated")
-		suite.Equal(tenantUUID, tenant.UUID, "tenantUUID and tenant.UUID should match")
-	})
-
-	suite.Run("tenant object created from flag", func() {
-		testUUID := "obj-creation-test"
-		viper.Set(TENANT_UUID_FLAG, testUUID)
-
-		_, tenant, err := fetchTenantOrUseFlag()
-
-		suite.NoError(err)
-		suite.IsType(&api.TenantInfo{}, tenant, "should return pointer to TenantInfo")
-		suite.Equal(testUUID, tenant.UUID)
+		suite.Equal(testUUID, tenantUUID)
 	})
 }

--- a/cmd/tenant_uuid_flag_test.go
+++ b/cmd/tenant_uuid_flag_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+)
+
+type TenantUUIDFlagTestSuite struct {
+	suite.Suite
+	originalTenantUUID string
+}
+
+func (suite *TenantUUIDFlagTestSuite) SetupTest() {
+	// Save original viper state before each test
+	suite.originalTenantUUID = viper.GetString(TENANT_UUID_FLAG)
+}
+
+func (suite *TenantUUIDFlagTestSuite) TearDownTest() {
+	// Restore original viper state after each test
+	viper.Set(TENANT_UUID_FLAG, suite.originalTenantUUID)
+}
+
+func TestTenantUUIDFlagTestSuite(t *testing.T) {
+	suite.Run(t, &TenantUUIDFlagTestSuite{})
+}
+
+func (suite *TenantUUIDFlagTestSuite) TestTenantUUIDFlagExists() {
+	// Verify the flag is registered as a persistent flag
+	flag := RootCmd.PersistentFlags().Lookup(TENANT_UUID_FLAG)
+	suite.NotNil(flag, "tenant-uuid flag should be registered")
+	suite.Equal("", flag.DefValue, "tenant-uuid flag should have empty default value")
+	suite.Equal("optional tenant-uuid", flag.Usage, "tenant-uuid flag should have correct usage description")
+}
+
+func (suite *TenantUUIDFlagTestSuite) TestTenantUUIDFlagConstant() {
+	// Verify the constant value is correct
+	suite.Equal("tenant-uuid", TENANT_UUID_FLAG)
+}
+
+func (suite *TenantUUIDFlagTestSuite) TestViperBindingForTenantUUID() {
+	// Test that viper can read the flag value
+	testUUID := "test-uuid-12345"
+	viper.Set(TENANT_UUID_FLAG, testUUID)
+
+	result := viper.GetString(TENANT_UUID_FLAG)
+	suite.Equal(testUUID, result)
+}
+
+func (suite *TenantUUIDFlagTestSuite) TestEmptyTenantUUIDFlag() {
+	// When flag is empty, viper should return empty string
+	viper.Set(TENANT_UUID_FLAG, "")
+
+	result := viper.GetString(TENANT_UUID_FLAG)
+	suite.Equal("", result)
+}
+
+func (suite *TenantUUIDFlagTestSuite) TestTenantUUIDFlagWithValidUUID() {
+	// Test with a valid UUID format
+	validUUID := "550e8400-e29b-41d4-a716-446655440000"
+	viper.Set(TENANT_UUID_FLAG, validUUID)
+
+	result := viper.GetString(TENANT_UUID_FLAG)
+	suite.Equal(validUUID, result)
+}
+
+// Test that all affected commands have access to the tenant-uuid flag
+func (suite *TenantUUIDFlagTestSuite) TestCommandsHaveAccessToTenantUUIDFlag() {
+	commands := []struct {
+		name string
+		cmd  interface{}
+	}{
+		{"IngestionKeyCmd", IngestionKeyCmd},
+		{"apiKeyCmd", apiKeyCmd},
+		{"getDatasourcesAPIKeyCmd", getDatasourcesAPIKeyCmd},
+		{"generateClientTokenCmd", generateClientTokenCmd},
+		{"serviceAccountTokenCmd", serviceAccountTokenCmd},
+	}
+
+	for _, tc := range commands {
+		suite.Run(tc.name, func() {
+			// All these commands are children of AuthCmd or RootCmd
+			// and should inherit the persistent flag
+			flag := RootCmd.PersistentFlags().Lookup(TENANT_UUID_FLAG)
+			suite.NotNil(flag, "Flag should be accessible to "+tc.name)
+		})
+	}
+}
+
+// Integration-style test verifying the pattern used in the fixed commands
+func (suite *TenantUUIDFlagTestSuite) TestTenantUUIDFlagPattern() {
+	// This test verifies the pattern: if tenantUUID = viper.GetString(TENANT_UUID_FLAG); tenantUUID == ""
+
+	suite.Run("flag not set - should be empty", func() {
+		viper.Set(TENANT_UUID_FLAG, "")
+		tenantUUID := viper.GetString(TENANT_UUID_FLAG)
+
+		if tenantUUID == "" {
+			// This is the expected path - should call fetchTenant()
+			suite.Empty(tenantUUID)
+		} else {
+			suite.Fail("Expected empty tenant UUID when flag not set")
+		}
+	})
+
+	suite.Run("flag set - should use flag value", func() {
+		expectedUUID := "my-custom-tenant-uuid"
+		viper.Set(TENANT_UUID_FLAG, expectedUUID)
+		tenantUUID := viper.GetString(TENANT_UUID_FLAG)
+
+		if tenantUUID == "" {
+			suite.Fail("Should not be empty when flag is set")
+		} else {
+			// This is the expected path - should NOT call fetchTenant()
+			suite.Equal(expectedUUID, tenantUUID)
+		}
+	})
+}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -109,7 +109,7 @@ func (client *Client) ServiceAccountToken(tenantUUID string) (*auth.SAToken, err
 
 	return saToken, nil
 }
-func (client *Client) GetDatasourcesAPIKey(tenant *TenantInfo, backendName string) (*auth.ApiKey, error) {
+func (client *Client) GetDatasourcesAPIKey(tenantUUID string, backendName string) (*auth.ApiKey, error) {
 	var err error
 
 	var url *url.URL
@@ -122,7 +122,7 @@ func (client *Client) GetDatasourcesAPIKey(tenant *TenantInfo, backendName strin
 		return nil, err
 	}
 
-	request.Header.Add(TenantUUIDHeader, tenant.UUID)
+	request.Header.Add(TenantUUIDHeader, tenantUUID)
 	request.Header.Add(BackendIDHeader, backendName)
 
 	var body []byte
@@ -138,7 +138,7 @@ func (client *Client) GetDatasourcesAPIKey(tenant *TenantInfo, backendName strin
 	return key, nil
 }
 
-func (client *Client) GetOrCreateClientToken(tenant *TenantInfo) (*auth.ApiKey, error) {
+func (client *Client) GetOrCreateClientToken(tenantUUID string) (*auth.ApiKey, error) {
 	var err error
 
 	var url *url.URL
@@ -151,7 +151,7 @@ func (client *Client) GetOrCreateClientToken(tenant *TenantInfo) (*auth.ApiKey, 
 		return nil, err
 	}
 
-	request.Header.Add(TenantUUIDHeader, tenant.UUID)
+	request.Header.Add(TenantUUIDHeader, tenantUUID)
 
 	var body []byte
 	if body, err = client.do(request); err != nil {


### PR DESCRIPTION
- Fixed a bug where the `--tenant-uuid` flag was being ignored by 5 CLI commands (get-ingestion-key, print-api-key, get-datasources-api-key, generate-client-token, generate-service-account-token). 
These commands now properly check for the flag value before falling back to interactive tenant selection.
- Added unit tests to prevent regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --tenant-uuid flag to let CLI commands accept a tenant UUID; commands will use it when provided and fall back to existing tenant lookup when omitted. API key, client token, datasource key, ingestion key, and service account flows now consistently operate using tenant UUIDs.

* **Tests**
  * Added comprehensive tests covering flag registration, command visibility, viper binding, empty vs valid UUID behavior, and tenant-resolution flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->