### PR TITLE
fix: panic when aborting on tenant selection

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -115,7 +115,16 @@ func fetchTenant() (*api.TenantInfo, error) {
 		}
 
 		tenantName := ui.GlobalWriter.SelectPrompt("Select tenant:", maps.Keys(tenantsByName))
-		return tenantsByName[tenantName], nil
+		if tenantName == "" {
+			return nil, errors.New("tenant selection cancelled")
+		}
+
+		tenant, ok := tenantsByName[tenantName]
+		if !ok {
+			return nil, errors.New("invalid tenant selected")
+		}
+
+		return tenant, nil
 	}
 }
 


### PR DESCRIPTION
fix panic when hitting ctrl-c during tenant selection.

before:
<img width="948" height="583" alt="Screenshot 2025-10-08 at 10 12 59" src="https://github.com/user-attachments/assets/9cc361de-95ac-47ca-bea3-17ac57d1e34b" />


after:
<img width="863" height="165" alt="Screenshot 2025-10-08 at 10 13 08" src="https://github.com/user-attachments/assets/fa145d58-a241-4e57-bc5d-7358c69c9c89" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved login tenant selection handling. The app now clearly reports when tenant selection is canceled and when an invalid tenant is chosen, instead of failing ambiguously.
  - Enhanced error messages during login to guide users in correcting selection issues and retrying smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->